### PR TITLE
Update Java symlink to jdk1.7.0_55-cloudera.

### DIFF
--- a/manifests/java5.pp
+++ b/manifests/java5.pp
@@ -90,7 +90,7 @@ class cloudera::java5 (
     'CentOS', 'RedHat', 'OEL', 'OracleLinux', 'SLES': {
       file { '/usr/java/default':
         ensure  => symlink,
-        target  => '/usr/java/jdk1.7.0_45-cloudera',
+        target  => '/usr/java/jdk1.7.0_55-cloudera',
         require => [ Anchor['cloudera::java5::begin'], Package['jdk'], ],
         before  => Anchor['cloudera::java5::end'],
       }


### PR DESCRIPTION
(resubmitting PR against correct branch)

The update release number of the jdk provided in Cloudera's repo has changed again. Here's a fix to the symlink for the latest version of CM/CDH (5.1.3).
