### PR TITLE
Added cloudera-scm-agent log_file key on config.ini template as a parameter

### DIFF
--- a/manifests/cm.pp
+++ b/manifests/cm.pp
@@ -71,7 +71,8 @@ class cloudera::cm (
   $server_port      = $cloudera::params::cm_server_port,
   $use_tls          = $cloudera::params::safe_cm_use_tls,
   $verify_cert_file = $cloudera::params::verify_cert_file,
-  $parcel_dir       = $cloudera::params::parcel_dir
+  $parcel_dir       = $cloudera::params::parcel_dir,
+  $log_file         = $cloudera::params::log_file
 ) inherits cloudera::params {
   # Validate our booleans
   validate_bool($autoupgrade)

--- a/manifests/cm.pp
+++ b/manifests/cm.pp
@@ -39,6 +39,11 @@
 #   The directory where parcels are downloaded and distributed.
 #   Default: /opt/cloudera/parcels
 #
+# [*log_file*]
+#   The file where the cloudera-scm-agent logs are saved.
+#   Default: /var/log/cloudera-scm-agent/cloudera-scm-agent.log
+#
+#
 # === Actions:
 #
 # Installs the packages.

--- a/manifests/cm5.pp
+++ b/manifests/cm5.pp
@@ -39,6 +39,10 @@
 #   The directory where parcels are downloaded and distributed.
 #   Default: /opt/cloudera/parcels
 #
+# [*log_file*]
+#   The file where the cloudera-scm-agent logs are saved.
+#   Default: /var/log/cloudera-scm-agent/cloudera-scm-agent.log
+#
 # === Actions:
 #
 # Installs the packages.
@@ -71,7 +75,8 @@ class cloudera::cm5 (
   $server_port      = $cloudera::params::cm_server_port,
   $use_tls          = $cloudera::params::safe_cm_use_tls,
   $verify_cert_file = $cloudera::params::verify_cert_file,
-  $parcel_dir       = $cloudera::params::parcel_dir
+  $parcel_dir       = $cloudera::params::parcel_dir,
+  $log_file         = $cloudera::params::log_file
 ) inherits cloudera::params {
   # Validate our booleans
   validate_bool($autoupgrade)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -304,7 +304,8 @@ class cloudera (
   $proxy            = $cloudera::params::proxy,
   $proxy_username   = $cloudera::params::proxy_username,
   $proxy_password   = $cloudera::params::proxy_password,
-  $parcel_dir       = $cloudera::params::parcel_dir
+  $parcel_dir       = $cloudera::params::parcel_dir,
+  $log_file         = $cloudera::params::log_file
 ) inherits cloudera::params {
   # Validate our booleans
   validate_bool($autoupgrade)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -217,6 +217,10 @@
 #   The directory where parcels are downloaded and distributed.
 #   Default: /opt/cloudera/parcels
 #
+# [*log_file*]
+#   The file where the cloudera-scm-agent logs are saved.
+#   Default: /var/log/cloudera-scm-agent/cloudera-scm-agent.log
+#
 # === Actions:
 #
 # Installs YUM repository configuration files.
@@ -386,6 +390,7 @@ class cloudera (
       verify_cert_file => $verify_cert_file,
       require          => $cloudera_cm_require,
       parcel_dir       => $parcel_dir,
+      log_file         => $log_file,
       before           => Anchor['cloudera::end'],
     }
     class { 'cloudera::cm5::repo':
@@ -587,6 +592,7 @@ class cloudera (
       verify_cert_file => $verify_cert_file,
       require          => $cloudera_cm_require,
       parcel_dir       => $parcel_dir,
+      log_file         => $log_file,
       before           => Anchor['cloudera::end'],
     }
     class { 'cloudera::cm::repo':

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -308,4 +308,9 @@ class cloudera::params {
     default => $::cloudera_parcel_dir,
   }
 
+  $log_file = $::cloudera_log_file ? {
+    undef => '/var/log/cloudera-scm-agent/cloudera-scm-agent.log',
+    default => $::cloudera_log_file,
+  }
+
 }

--- a/templates/scm-config.ini.erb
+++ b/templates/scm-config.ini.erb
@@ -24,7 +24,7 @@ listening_hostname=<%= scope.lookupvar('::fqdn') %>
 # will also have a small amount of output (from before logging
 # is initialized.)
 <% if @log_file -%>
-# log_file=<%= @log_file %>
+log_file=<%= @log_file %>
 <% else -%>
 # log_file=/var/log/cloudera-scm-agent/cloudera-scm-agent.log
 <% end -%>

--- a/templates/scm-config.ini.erb
+++ b/templates/scm-config.ini.erb
@@ -24,7 +24,7 @@ listening_hostname=<%= scope.lookupvar('::fqdn') %>
 # will also have a small amount of output (from before logging
 # is initialized.)
 <% if @log_file -%>
-# log_file=<%= log_file %>
+# log_file=<%= @log_file %>
 <% else -%>
 # log_file=/var/log/cloudera-scm-agent/cloudera-scm-agent.log
 <% end -%>

--- a/templates/scm-config.ini.erb
+++ b/templates/scm-config.ini.erb
@@ -23,7 +23,11 @@ listening_hostname=<%= scope.lookupvar('::fqdn') %>
 # via the init.d script, /var/log/cloudera-scm-agent/cloudera-scm-agent.out
 # will also have a small amount of output (from before logging
 # is initialized.)
+<% if @log_file -%>
+# log_file=<%= log_file %>
+<% else -%>
 # log_file=/var/log/cloudera-scm-agent/cloudera-scm-agent.log
+<% end -%>
 
 # Parcel directory
 # Unpacked parcels will be stored in this directory


### PR DESCRIPTION
This change exposes the log_file parameter on the manifest to populate the log_file key on the config.ini file.