### PR TITLE
Fix embedded db management - Issue #26

### DIFF
--- a/manifests/cm/server.pp
+++ b/manifests/cm/server.pp
@@ -179,6 +179,12 @@ class cloudera::cm::server (
       require => Package['cloudera-manager-server'],
       notify  => Service['cloudera-scm-server'],
     }
+  } else {
+    file { '/etc/cloudera-scm-server/db.properties':
+      ensure  => $file_ensure,
+      path    => '/etc/cloudera-scm-server/db.properties',
+      require => Package['cloudera-manager-server'],
+    }
   }
 
   package { 'cloudera-manager-server':

--- a/manifests/cm/server.pp
+++ b/manifests/cm/server.pp
@@ -171,19 +171,19 @@ class cloudera::cm::server (
 
   if $db_type != 'embedded' {
     $file_content = template("${module_name}/db.properties.erb")
+
+    file { '/etc/cloudera-scm-server/db.properties':
+      ensure  => $file_ensure,
+      path    => '/etc/cloudera-scm-server/db.properties',
+      content => $file_content,
+      require => Package['cloudera-manager-server'],
+      notify  => Service['cloudera-scm-server'],
+    }
   }
 
   package { 'cloudera-manager-server':
     ensure => $package_ensure,
     tag    => 'cloudera-manager',
-  }
-
-  file { '/etc/cloudera-scm-server/db.properties':
-    ensure  => $file_ensure,
-    path    => '/etc/cloudera-scm-server/db.properties',
-    content => $file_content,
-    require => Package['cloudera-manager-server'],
-    notify  => Service['cloudera-scm-server'],
   }
 
   service { 'cloudera-scm-server':

--- a/manifests/cm5/server.pp
+++ b/manifests/cm5/server.pp
@@ -179,6 +179,12 @@ class cloudera::cm5::server (
       require => Package['cloudera-manager-server'],
       notify  => Service['cloudera-scm-server'],
     }
+  } else {
+    file { '/etc/cloudera-scm-server/db.properties':
+      ensure  => $file_ensure,
+      path    => '/etc/cloudera-scm-server/db.properties',
+      require => Package['cloudera-manager-server'],
+    }
   }
 
   package { 'cloudera-manager-server':

--- a/manifests/cm5/server.pp
+++ b/manifests/cm5/server.pp
@@ -171,6 +171,14 @@ class cloudera::cm5::server (
 
   if $db_type != 'embedded' {
     $file_content = template("${module_name}/db.properties.erb")
+
+    file { '/etc/cloudera-scm-server/db.properties':
+      ensure  => $file_ensure,
+      path    => '/etc/cloudera-scm-server/db.properties',
+      content => $file_content,
+      require => Package['cloudera-manager-server'],
+      notify  => Service['cloudera-scm-server'],
+    }
   }
 
   package { 'cloudera-manager-server':
@@ -183,14 +191,6 @@ class cloudera::cm5::server (
       ensure => $package_ensure,
       tag    => 'cloudera-manager',
     }
-  }
-
-  file { '/etc/cloudera-scm-server/db.properties':
-    ensure  => $file_ensure,
-    path    => '/etc/cloudera-scm-server/db.properties',
-    content => $file_content,
-    require => Package['cloudera-manager-server'],
-    notify  => Service['cloudera-scm-server'],
   }
 
   service { 'cloudera-scm-server':


### PR DESCRIPTION
This change seems to fix the issue I had with the embedded db.
If the db_type is not 'embedded', then we can use the template for the 'db.properties' file. With that, the creation of the embedded db is not a problem anymore.