### PR TITLE
Added manage_sysctl flag to control the changes to sysctl.conf

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -549,6 +549,10 @@ Default: absent
 The directory where parcels are downloaded and distributed.
 Default: /opt/cloudera/parcels
 
+####`manage_sysctl`
+
+Boolean flag that determines whether this module will manage sysctl or not.  There may be other modules managing sysctl and this boolean can be used to resolve those conflicts.
+
 ##Limitations
 
 ###OS Support:

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -217,6 +217,11 @@
 #   The directory where parcels are downloaded and distributed.
 #   Default: /opt/cloudera/parcels
 #
+# [*manage_sysctl*]
+#   Boolean flag that determines whether this module will manage sysctl or not.
+#   Need to resolve conflicts with other modules that manage sysctl.
+#   Default: true
+#
 # === Actions:
 #
 # Installs YUM repository configuration files.
@@ -304,7 +309,8 @@ class cloudera (
   $proxy            = $cloudera::params::proxy,
   $proxy_username   = $cloudera::params::proxy_username,
   $proxy_password   = $cloudera::params::proxy_password,
-  $parcel_dir       = $cloudera::params::parcel_dir
+  $parcel_dir       = $cloudera::params::parcel_dir,
+  $manage_sysctl    = $cloudera::params::manage_sysctl
 ) inherits cloudera::params {
   # Validate our booleans
   validate_bool($autoupgrade)
@@ -315,17 +321,20 @@ class cloudera (
   validate_bool($install_java)
   validate_bool($install_jce)
   validate_bool($install_cmserver)
+  validate_bool($manage_sysctl)
 
   anchor { 'cloudera::begin': }
   anchor { 'cloudera::end': }
 
-  sysctl { 'vm.swappiness':
-    ensure  => $ensure,
-    value   => '0',
-    apply   => true,
-    comment => 'Cloudera recommended setting.',
-    require => Anchor['cloudera::begin'],
-    before  => Anchor['cloudera::end'],
+  if $manage_sysctl {
+    sysctl { 'vm.swappiness':
+      ensure  => $ensure,
+      value   => '0',
+      apply   => true,
+      comment => 'Clodera recommended setting.',
+      require => Anchor['cloudera::begin'],
+      before  => Anchor['cloudera::end'],
+    }
   }
 
   exec { 'disable_transparent_hugepage_defrag':

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -98,6 +98,11 @@ class cloudera::params {
     default => $::cloudera_proxy_password,
   }
 
+  $manage_sysctl = $::cloudera_manage_sysctl ? {
+    undef => true,
+    default => $::cloudera_manage_sysctl,
+  }
+
   # Since the top scope variable could be a string (if from an ENC), we might
   # need to convert it to a boolean.
   $autoupgrade = $::cloudera_autoupgrade ? {


### PR DESCRIPTION
We use a different sysctl module and thus needed a flag to override your use of sysctl.
