### PR TITLE
Allow users to set vm.swappiness.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -217,6 +217,10 @@
 #   The directory where parcels are downloaded and distributed.
 #   Default: /opt/cloudera/parcels
 #
+# [*vm_swappiness*]
+#   The sysctl value for vm.swappiness.
+#   Default: 0
+#
 # === Actions:
 #
 # Installs YUM repository configuration files.
@@ -304,7 +308,8 @@ class cloudera (
   $proxy            = $cloudera::params::proxy,
   $proxy_username   = $cloudera::params::proxy_username,
   $proxy_password   = $cloudera::params::proxy_password,
-  $parcel_dir       = $cloudera::params::parcel_dir
+  $parcel_dir       = $cloudera::params::parcel_dir,
+  $vm_swappiness    = $cloudera::params::vm_swappiness
 ) inherits cloudera::params {
   # Validate our booleans
   validate_bool($autoupgrade)
@@ -315,13 +320,14 @@ class cloudera (
   validate_bool($install_java)
   validate_bool($install_jce)
   validate_bool($install_cmserver)
+  validate_integer($vm_swappiness, 100, 0)
 
   anchor { 'cloudera::begin': }
   anchor { 'cloudera::end': }
 
   sysctl { 'vm.swappiness':
     ensure  => $ensure,
-    value   => '0',
+    value   => "${vm_swappiness}",
     apply   => true,
     comment => 'Clodera recommended setting.',
     require => Anchor['cloudera::begin'],

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -71,7 +71,12 @@ class cloudera::params {
     default => $::cloudera_oozie_ext,
   }
 
-### The following parameters should not need to be changed.
+  $vm_swappiness = $::cloudera_vm_swappiness ? {
+    undef => 0,
+    default => $::cloudera_vm_swappiness,
+  }
+
+  ### The following parameters should not need to be changed.
 
   $ensure = $::cloudera_ensure ? {
     undef => 'present',


### PR DESCRIPTION
Previously Cloudera recommended setting vm.swappiness to 0 but with
recent kernels the suggested value is 1.
http://www.cloudera.com/documentation/enterprise/5-5-x/topics/cdh_admin_performance.html

This change allows users to set vm.swappiness to their liking,
maintaining backward compatibility (defaults to 0).
