### PR TITLE
Manage cloudera db

### DIFF
--- a/manifests/cm.pp
+++ b/manifests/cm.pp
@@ -39,6 +39,11 @@
 #   The directory where parcels are downloaded and distributed.
 #   Default: /opt/cloudera/parcels
 #
+# [*manage_db_properties*]
+#   Boolean flag that determines whether this module will manage /etc/cloudera-scm-serer/db.properties file or not.
+#   Need to resolve conflicts with other modules that manage the file.
+#   Default: true
+#
 # === Actions:
 #
 # Installs the packages.
@@ -71,11 +76,13 @@ class cloudera::cm (
   $server_port      = $cloudera::params::cm_server_port,
   $use_tls          = $cloudera::params::safe_cm_use_tls,
   $verify_cert_file = $cloudera::params::verify_cert_file,
-  $parcel_dir       = $cloudera::params::parcel_dir
+  $parcel_dir       = $cloudera::params::parcel_dir,
+  $manage_db_properties    = $cloudera::params::manage_db_properties
 ) inherits cloudera::params {
   # Validate our booleans
   validate_bool($autoupgrade)
   validate_bool($use_tls)
+  validate_bool($manage_db_properties)
 
   case $ensure {
     /(present)/: {

--- a/manifests/cm.pp
+++ b/manifests/cm.pp
@@ -39,7 +39,7 @@
 #   The directory where parcels are downloaded and distributed.
 #   Default: /opt/cloudera/parcels
 #
-# [*manage_db_properties*]
+# [*manage_db_props*]
 #   Boolean flag that determines whether this module will manage /etc/cloudera-scm-serer/db.properties file or not.
 #   Need to resolve conflicts with other modules that manage the file.
 #   Default: true
@@ -77,12 +77,12 @@ class cloudera::cm (
   $use_tls          = $cloudera::params::safe_cm_use_tls,
   $verify_cert_file = $cloudera::params::verify_cert_file,
   $parcel_dir       = $cloudera::params::parcel_dir,
-  $manage_db_properties    = $cloudera::params::manage_db_properties
+  $manage_db_props  = $cloudera::params::manage_db_props
 ) inherits cloudera::params {
   # Validate our booleans
   validate_bool($autoupgrade)
   validate_bool($use_tls)
-  validate_bool($manage_db_properties)
+  validate_bool($manage_db_props)
 
   case $ensure {
     /(present)/: {

--- a/manifests/cm/server.pp
+++ b/manifests/cm/server.pp
@@ -78,6 +78,12 @@
 #   The password used to protect the keystore.
 #   Default: none
 #
+# [*manage_db_properties*]
+#   Boolean flag that determines whether this module will manage /etc/cloudera-scm-serer/db.properties file or not.
+#   Need to resolve conflicts with other modules that manage the file.
+#   Default: true
+#
+#
 # === Actions:
 #
 # Installs the packages.
@@ -133,11 +139,13 @@ class cloudera::cm::server (
   $server_cert_file  = $cloudera::params::server_cert_file,
   $server_key_file   = $cloudera::params::server_key_file,
   $server_chain_file = $cloudera::params::server_chain_file,
-  $server_keypw      = $cloudera::params::server_keypw
+  $server_keypw      = $cloudera::params::server_keypw,
+  $manage_db_properties    = $cloudera::params::manage_db_properties
 ) inherits cloudera::params {
   # Validate our booleans
   validate_bool($autoupgrade)
   validate_bool($use_tls)
+  validate_bool($manage_db_properties)
   # Validate our regular expressions
   $states = [ '^embedded$', '^mysql$','^oracle$','^postgresql$' ]
   validate_re($db_type, $states, '$db_type must be either embedded, mysql, oracle, or postgresql.')
@@ -178,13 +186,15 @@ class cloudera::cm::server (
     tag    => 'cloudera-manager',
   }
 
-  file { '/etc/cloudera-scm-server/db.properties':
-    ensure  => $file_ensure,
-    path    => '/etc/cloudera-scm-server/db.properties',
-    content => $file_content,
-    require => Package['cloudera-manager-server'],
-    notify  => Service['cloudera-scm-server'],
-  }
+ if $manage_db_properties {
+   file { '/etc/cloudera-scm-server/db.properties':
+     ensure  => $file_ensure,
+     path    => '/etc/cloudera-scm-server/db.properties',
+     content => $file_content,
+     require => Package['cloudera-manager-server'],
+     notify  => Service['cloudera-scm-server'],
+   }
+ }
 
   service { 'cloudera-scm-server':
     ensure     => $service_ensure_real,

--- a/manifests/cm/server.pp
+++ b/manifests/cm/server.pp
@@ -186,15 +186,15 @@ class cloudera::cm::server (
     tag    => 'cloudera-manager',
   }
 
- if $manage_db_properties {
-   file { '/etc/cloudera-scm-server/db.properties':
-     ensure  => $file_ensure,
-     path    => '/etc/cloudera-scm-server/db.properties',
-     content => $file_content,
-     require => Package['cloudera-manager-server'],
-     notify  => Service['cloudera-scm-server'],
-   }
- }
+  if $manage_db_properties {
+    file { '/etc/cloudera-scm-server/db.properties':
+      ensure  => $file_ensure,
+      path    => '/etc/cloudera-scm-server/db.properties',
+      content => $file_content,
+      require => Package['cloudera-manager-server'],
+      notify  => Service['cloudera-scm-server'],
+    }
+  }
 
   service { 'cloudera-scm-server':
     ensure     => $service_ensure_real,

--- a/manifests/cm/server.pp
+++ b/manifests/cm/server.pp
@@ -78,7 +78,7 @@
 #   The password used to protect the keystore.
 #   Default: none
 #
-# [*manage_db_properties*]
+# [*manage_db_props*]
 #   Boolean flag that determines whether this module will manage /etc/cloudera-scm-serer/db.properties file or not.
 #   Need to resolve conflicts with other modules that manage the file.
 #   Default: true
@@ -140,12 +140,12 @@ class cloudera::cm::server (
   $server_key_file   = $cloudera::params::server_key_file,
   $server_chain_file = $cloudera::params::server_chain_file,
   $server_keypw      = $cloudera::params::server_keypw,
-  $manage_db_properties    = $cloudera::params::manage_db_properties
+  $manage_db_props   = $cloudera::params::manage_db_props
 ) inherits cloudera::params {
   # Validate our booleans
   validate_bool($autoupgrade)
   validate_bool($use_tls)
-  validate_bool($manage_db_properties)
+  validate_bool($manage_db_props)
   # Validate our regular expressions
   $states = [ '^embedded$', '^mysql$','^oracle$','^postgresql$' ]
   validate_re($db_type, $states, '$db_type must be either embedded, mysql, oracle, or postgresql.')
@@ -186,7 +186,7 @@ class cloudera::cm::server (
     tag    => 'cloudera-manager',
   }
 
-  if $manage_db_properties {
+  if $manage_db_props {
     file { '/etc/cloudera-scm-server/db.properties':
       ensure  => $file_ensure,
       path    => '/etc/cloudera-scm-server/db.properties',

--- a/manifests/cm5.pp
+++ b/manifests/cm5.pp
@@ -39,7 +39,7 @@
 #   The directory where parcels are downloaded and distributed.
 #   Default: /opt/cloudera/parcels
 #
-# [*manage_db_properties*]
+# [*manage_db_props*]
 #   Boolean flag that determines whether this module will manage /etc/cloudera-scm-serer/db.properties file or not.
 #   Need to resolve conflicts with other modules that manage the file.
 #   Default: true
@@ -77,12 +77,12 @@ class cloudera::cm5 (
   $use_tls          = $cloudera::params::safe_cm_use_tls,
   $verify_cert_file = $cloudera::params::verify_cert_file,
   $parcel_dir       = $cloudera::params::parcel_dir,
-  $manage_db_properties    = $cloudera::params::manage_db_properties
+  $manage_db_props  = $cloudera::params::manage_db_props
 ) inherits cloudera::params {
   # Validate our booleans
   validate_bool($autoupgrade)
   validate_bool($use_tls)
-  validate_bool($manage_db_properties)
+  validate_bool($manage_db_props)
 
   case $ensure {
     /(present)/: {

--- a/manifests/cm5.pp
+++ b/manifests/cm5.pp
@@ -39,6 +39,11 @@
 #   The directory where parcels are downloaded and distributed.
 #   Default: /opt/cloudera/parcels
 #
+# [*manage_db_properties*]
+#   Boolean flag that determines whether this module will manage /etc/cloudera-scm-serer/db.properties file or not.
+#   Need to resolve conflicts with other modules that manage the file.
+#   Default: true
+#
 # === Actions:
 #
 # Installs the packages.
@@ -71,11 +76,13 @@ class cloudera::cm5 (
   $server_port      = $cloudera::params::cm_server_port,
   $use_tls          = $cloudera::params::safe_cm_use_tls,
   $verify_cert_file = $cloudera::params::verify_cert_file,
-  $parcel_dir       = $cloudera::params::parcel_dir
+  $parcel_dir       = $cloudera::params::parcel_dir,
+  $manage_db_properties    = $cloudera::params::manage_db_properties
 ) inherits cloudera::params {
   # Validate our booleans
   validate_bool($autoupgrade)
   validate_bool($use_tls)
+  validate_bool($manage_db_properties)
 
   case $ensure {
     /(present)/: {

--- a/manifests/cm5/server.pp
+++ b/manifests/cm5/server.pp
@@ -192,15 +192,15 @@ class cloudera::cm5::server (
     }
   }
 
- if $manage_db_properties {
-   file { '/etc/cloudera-scm-server/db.properties':
-     ensure  => $file_ensure,
-     path    => '/etc/cloudera-scm-server/db.properties',
-     content => $file_content,
-     require => Package['cloudera-manager-server'],
-     notify  => Service['cloudera-scm-server'],
-   }
- }
+  if $manage_db_properties {
+    file { '/etc/cloudera-scm-server/db.properties':
+      ensure  => $file_ensure,
+      path    => '/etc/cloudera-scm-server/db.properties',
+      content => $file_content,
+      require => Package['cloudera-manager-server'],
+      notify  => Service['cloudera-scm-server'],
+    }
+  }
 
   service { 'cloudera-scm-server':
     ensure     => $service_ensure_real,

--- a/manifests/cm5/server.pp
+++ b/manifests/cm5/server.pp
@@ -78,6 +78,11 @@
 #   The password used to protect the keystore.
 #   Default: none
 #
+# [*manage_db_properties*]
+#   Boolean flag that determines whether this module will manage /etc/cloudera-scm-serer/db.properties file or not.
+#   Need to resolve conflicts with other modules that manage the file.
+#   Default: true
+#
 # === Actions:
 #
 # Installs the packages.
@@ -133,11 +138,13 @@ class cloudera::cm5::server (
   $server_cert_file  = $cloudera::params::server_cert_file,
   $server_key_file   = $cloudera::params::server_key_file,
   $server_chain_file = $cloudera::params::server_chain_file,
-  $server_keypw      = $cloudera::params::server_keypw
+  $server_keypw      = $cloudera::params::server_keypw,
+  $manage_db_properties    = $cloudera::params::manage_db_properties
 ) inherits cloudera::params {
   # Validate our booleans
   validate_bool($autoupgrade)
   validate_bool($use_tls)
+  validate_bool($manage_db_properties)
   # Validate our regular expressions
   $states = [ '^embedded$', '^mysql$','^oracle$','^postgresql$' ]
   validate_re($db_type, $states, '$db_type must be either embedded, mysql, oracle, or postgresql.')
@@ -185,13 +192,15 @@ class cloudera::cm5::server (
     }
   }
 
-  file { '/etc/cloudera-scm-server/db.properties':
-    ensure  => $file_ensure,
-    path    => '/etc/cloudera-scm-server/db.properties',
-    content => $file_content,
-    require => Package['cloudera-manager-server'],
-    notify  => Service['cloudera-scm-server'],
-  }
+ if $manage_db_properties {
+   file { '/etc/cloudera-scm-server/db.properties':
+     ensure  => $file_ensure,
+     path    => '/etc/cloudera-scm-server/db.properties',
+     content => $file_content,
+     require => Package['cloudera-manager-server'],
+     notify  => Service['cloudera-scm-server'],
+   }
+ }
 
   service { 'cloudera-scm-server':
     ensure     => $service_ensure_real,

--- a/manifests/cm5/server.pp
+++ b/manifests/cm5/server.pp
@@ -78,7 +78,7 @@
 #   The password used to protect the keystore.
 #   Default: none
 #
-# [*manage_db_properties*]
+# [*manage_db_props*]
 #   Boolean flag that determines whether this module will manage /etc/cloudera-scm-serer/db.properties file or not.
 #   Need to resolve conflicts with other modules that manage the file.
 #   Default: true
@@ -139,12 +139,12 @@ class cloudera::cm5::server (
   $server_key_file   = $cloudera::params::server_key_file,
   $server_chain_file = $cloudera::params::server_chain_file,
   $server_keypw      = $cloudera::params::server_keypw,
-  $manage_db_properties    = $cloudera::params::manage_db_properties
+  $manage_db_props   = $cloudera::params::manage_db_props
 ) inherits cloudera::params {
   # Validate our booleans
   validate_bool($autoupgrade)
   validate_bool($use_tls)
-  validate_bool($manage_db_properties)
+  validate_bool($manage_db_props)
   # Validate our regular expressions
   $states = [ '^embedded$', '^mysql$','^oracle$','^postgresql$' ]
   validate_re($db_type, $states, '$db_type must be either embedded, mysql, oracle, or postgresql.')
@@ -192,7 +192,7 @@ class cloudera::cm5::server (
     }
   }
 
-  if $manage_db_properties {
+  if $manage_db_props {
     file { '/etc/cloudera-scm-server/db.properties':
       ensure  => $file_ensure,
       path    => '/etc/cloudera-scm-server/db.properties',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -628,7 +628,7 @@ class cloudera (
         server_key_file   => $server_key_file,
         server_chain_file => $server_chain_file,
         server_keypw      => $server_keypw,
-	manage_db_properties => $manage_db_properties,
+        manage_db_properties => $manage_db_properties,
         require              => $cloudera_cm_require,
         before               => Anchor['cloudera::end'],
       }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -425,7 +425,7 @@ class cloudera (
         server_key_file   => $server_key_file,
         server_chain_file => $server_chain_file,
         server_keypw      => $server_keypw,
-	manage_db_properties => $manage_db_properties,
+        manage_db_properties => $manage_db_properties,
         require              => $cloudera_cm_require,
         before               => Anchor['cloudera::end'],
       }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -217,7 +217,7 @@
 #   The directory where parcels are downloaded and distributed.
 #   Default: /opt/cloudera/parcels
 #
-# [*manage_db_properties*]
+# [*manage_db_props*]
 #   Boolean flag that determines whether this module will manage /etc/cloudera-scm-serer/db.properties file or not.
 #   Need to resolve conflicts with other modules that manage the file.
 #   Default: true
@@ -310,7 +310,7 @@ class cloudera (
   $proxy_username   = $cloudera::params::proxy_username,
   $proxy_password   = $cloudera::params::proxy_password,
   $parcel_dir       = $cloudera::params::parcel_dir,
-  $manage_db_properties    = $cloudera::params::manage_db_properties
+  $manage_db_props  = $cloudera::params::manage_db_props
 ) inherits cloudera::params {
   # Validate our booleans
   validate_bool($autoupgrade)
@@ -321,7 +321,7 @@ class cloudera (
   validate_bool($install_java)
   validate_bool($install_jce)
   validate_bool($install_cmserver)
-  validate_bool($manage_db_properties)
+  validate_bool($manage_db_props)
 
   anchor { 'cloudera::begin': }
   anchor { 'cloudera::end': }
@@ -392,7 +392,7 @@ class cloudera (
       verify_cert_file => $verify_cert_file,
       require          => $cloudera_cm_require,
       parcel_dir       => $parcel_dir,
-      manage_db_properties => $manage_db_properties,
+      manage_db_props  => $manage_db_props,
       before               => Anchor['cloudera::end'],
     }
     class { 'cloudera::cm5::repo':
@@ -425,9 +425,9 @@ class cloudera (
         server_key_file   => $server_key_file,
         server_chain_file => $server_chain_file,
         server_keypw      => $server_keypw,
-        manage_db_properties => $manage_db_properties,
-        require              => $cloudera_cm_require,
-        before               => Anchor['cloudera::end'],
+        manage_db_props   => $manage_db_props,
+        require           => $cloudera_cm_require,
+        before            => Anchor['cloudera::end'],
       }
     }
     # Skip installing the CDH RPMs if we are going to use parcels.
@@ -595,8 +595,8 @@ class cloudera (
       verify_cert_file => $verify_cert_file,
       require          => $cloudera_cm_require,
       parcel_dir       => $parcel_dir,
-      manage_db_properties => $manage_db_properties,
-      before               => Anchor['cloudera::end'],
+      manage_db_props  => $manage_db_props,
+      before           => Anchor['cloudera::end'],
     }
     class { 'cloudera::cm::repo':
       ensure         => $ensure,
@@ -628,9 +628,9 @@ class cloudera (
         server_key_file   => $server_key_file,
         server_chain_file => $server_chain_file,
         server_keypw      => $server_keypw,
-        manage_db_properties => $manage_db_properties,
-        require              => $cloudera_cm_require,
-        before               => Anchor['cloudera::end'],
+        manage_db_props   => $manage_db_props,
+        require           => $cloudera_cm_require,
+        before            => Anchor['cloudera::end'],
       }
     }
     # Skip installing the CDH RPMs if we are going to use parcels.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -217,6 +217,11 @@
 #   The directory where parcels are downloaded and distributed.
 #   Default: /opt/cloudera/parcels
 #
+# [*manage_db_properties*]
+#   Boolean flag that determines whether this module will manage /etc/cloudera-scm-serer/db.properties file or not.
+#   Need to resolve conflicts with other modules that manage the file.
+#   Default: true
+#
 # === Actions:
 #
 # Installs YUM repository configuration files.
@@ -304,7 +309,8 @@ class cloudera (
   $proxy            = $cloudera::params::proxy,
   $proxy_username   = $cloudera::params::proxy_username,
   $proxy_password   = $cloudera::params::proxy_password,
-  $parcel_dir       = $cloudera::params::parcel_dir
+  $parcel_dir       = $cloudera::params::parcel_dir,
+  $manage_db_properties    = $cloudera::params::manage_db_properties
 ) inherits cloudera::params {
   # Validate our booleans
   validate_bool($autoupgrade)
@@ -315,6 +321,7 @@ class cloudera (
   validate_bool($install_java)
   validate_bool($install_jce)
   validate_bool($install_cmserver)
+  validate_bool($manage_db_properties)
 
   anchor { 'cloudera::begin': }
   anchor { 'cloudera::end': }
@@ -385,7 +392,8 @@ class cloudera (
       verify_cert_file => $verify_cert_file,
       require          => $cloudera_cm_require,
       parcel_dir       => $parcel_dir,
-      before           => Anchor['cloudera::end'],
+      manage_db_properties => $manage_db_properties,
+      before               => Anchor['cloudera::end'],
     }
     class { 'cloudera::cm5::repo':
       ensure         => $ensure,
@@ -417,8 +425,9 @@ class cloudera (
         server_key_file   => $server_key_file,
         server_chain_file => $server_chain_file,
         server_keypw      => $server_keypw,
-        require           => $cloudera_cm_require,
-        before            => Anchor['cloudera::end'],
+	manage_db_properties => $manage_db_properties,
+        require              => $cloudera_cm_require,
+        before               => Anchor['cloudera::end'],
       }
     }
     # Skip installing the CDH RPMs if we are going to use parcels.
@@ -586,7 +595,8 @@ class cloudera (
       verify_cert_file => $verify_cert_file,
       require          => $cloudera_cm_require,
       parcel_dir       => $parcel_dir,
-      before           => Anchor['cloudera::end'],
+      manage_db_properties => $manage_db_properties,
+      before               => Anchor['cloudera::end'],
     }
     class { 'cloudera::cm::repo':
       ensure         => $ensure,
@@ -618,8 +628,9 @@ class cloudera (
         server_key_file   => $server_key_file,
         server_chain_file => $server_chain_file,
         server_keypw      => $server_keypw,
-        require           => $cloudera_cm_require,
-        before            => Anchor['cloudera::end'],
+	manage_db_properties => $manage_db_properties,
+        require              => $cloudera_cm_require,
+        before               => Anchor['cloudera::end'],
       }
     }
     # Skip installing the CDH RPMs if we are going to use parcels.

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -188,8 +188,8 @@ class cloudera::params {
     $safe_manage_db_properties = str2bool($manage_db_properties)
   } else {
     $safe_manage_db_properties = $manage_db_properties
+  }
  
-
   if $::operatingsystemmajrelease { # facter 1.7+
     $majdistrelease = $::operatingsystemmajrelease
   } elsif $::lsbmajdistrelease {    # requires LSB to already be installed

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -180,6 +180,16 @@ class cloudera::params {
     $safe_install_cmserver = $install_cmserver
   }
 
+  $manage_db_properties = $::cloudera_manage_db_properties ? {
+    undef => true,
+    default => $::cloudera_manage_db_properties,
+  }
+  if is_string($manage_db_properties) {
+    $safe_manage_db_properties = str2bool($manage_db_properties)
+  } else {
+    $safe_manage_db_properties = $manage_db_properties
+ 
+
   if $::operatingsystemmajrelease { # facter 1.7+
     $majdistrelease = $::operatingsystemmajrelease
   } elsif $::lsbmajdistrelease {    # requires LSB to already be installed

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -189,7 +189,7 @@ class cloudera::params {
   } else {
     $safe_manage_db_properties = $manage_db_properties
   }
- 
+
   if $::operatingsystemmajrelease { # facter 1.7+
     $majdistrelease = $::operatingsystemmajrelease
   } elsif $::lsbmajdistrelease {    # requires LSB to already be installed

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -180,14 +180,14 @@ class cloudera::params {
     $safe_install_cmserver = $install_cmserver
   }
 
-  $manage_db_properties = $::cloudera_manage_db_properties ? {
+  $manage_db_props = $::cloudera_manage_db_props ? {
     undef => true,
-    default => $::cloudera_manage_db_properties,
+    default => $::cloudera_manage_db_props,
   }
-  if is_string($manage_db_properties) {
-    $safe_manage_db_properties = str2bool($manage_db_properties)
+  if is_string($manage_db_props) {
+    $safe_manage_db_props = str2bool($manage_db_props)
   } else {
-    $safe_manage_db_properties = $manage_db_properties
+    $safe_manage_db_props = $manage_db_props
   }
 
   if $::operatingsystemmajrelease { # facter 1.7+


### PR DESCRIPTION
We have a requirement to set some extra parameters in /etc/cloudera-scm-server/db.properties file to tweak a cloudera bug. Since the file is managed by external module , the change in code to manage cloudera db properties file needs to be implemented.