### PR TITLE
Disabled transparent hugepage in transparent_hugepage/enabled

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ coverage/
 *.swp
 .vendor/
 .vendor
+.idea/

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -357,6 +357,12 @@ class cloudera (
     path     => '/usr/bin:/usr/sbin:/bin:/sbin',
     provider => 'shell',
   }
+  exec { 'disable_transparent_hugepage_enabled':
+      command  => 'if [ -f /sys/kernel/mm/transparent_hugepage/enabled ]; then echo never > /sys/kernel/mm/transparent_hugepage/enabled; fi',
+      unless   => 'if [ -f /sys/kernel/mm/transparent_hugepage/enabled ]; then grep -q "\[never\]" /sys/kernel/mm/transparent_hugepage/enabled; fi',
+      path     => '/usr/bin:/usr/sbin:/bin:/sbin',
+      provider => 'shell',
+  }
 
   if $install_lzo {
     class { '::cloudera::lzo':

--- a/spec/classes/cloudera_init_spec.rb
+++ b/spec/classes/cloudera_init_spec.rb
@@ -35,6 +35,7 @@ describe 'cloudera', :type => 'class' do
     )}
     it { should contain_exec('disable_transparent_hugepage_defrag') }
     it { should contain_exec('disable_redhat_transparent_hugepage_defrag') }
+    it { should contain_exec('disable_transparent_hugepage_enabled') }
     it { should contain_class('cloudera::java5').with_ensure('present') }
     it { should_not contain_class('cloudera::java5::jce') }
     it { should contain_class('cloudera::cm5::repo').with_ensure('present') }


### PR DESCRIPTION
When running the host inspector in Cloudera Manager it complains that transparent hugepage should also be disabled in `/sys/kernel/mm/transparent_hugepage/enabled`. This pull request adds an exec in the same form as for the other files to disable it in `/sys/kernel/mm/transparent_hugepage/enabled`.

Additional change: I added `.idea` (for IntelliJ and RubyMine users) as an ignored directory to `.gitignore`.