### PR TITLE
Exchanged nanliu/staging with puppet/staging

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -10,7 +10,9 @@ fixtures:
     concat:
       repo: "https://github.com/puppetlabs/puppetlabs-concat.git"
       ref: "1.2.1"
-    staging: "https://github.com/nanliu/puppet-staging.git"
+    staging:
+      repo: "https://github.com/voxpupuli/puppet-staging"
+      ref: "3.2.0"
     epel:
       repo: "https://github.com/stahnma/puppet-module-epel.git"
       ref: "1.2.2"

--- a/metadata.json
+++ b/metadata.json
@@ -22,8 +22,8 @@
       "name": "puppetlabs/postgresql"
     },
     {
-      "version_requirement": "1.x",
-      "name": "nanliu/staging"
+      "version_requirement": "3.x",
+      "name": "puppet/staging"
     },
     {
       "version_requirement": "1.x",


### PR DESCRIPTION
Currently this module relies on nanliu/staging. This creates conflicts with other module, which mostly use puppet/staging instead, used in a complete cluster installation. This PR exchanges the nanliu against the puppet dependency.