### PR TITLE
Changed upper bound for puppetlabs-mysql dependency

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -3,7 +3,7 @@ fixtures:
     stdlib: "https://github.com/puppetlabs/puppetlabs-stdlib.git"
     mysql:
       repo: "https://github.com/puppetlabs/puppetlabs-mysql.git"
-      ref: "3.11.0"
+      ref: "5.3.0"
     postgresql:
       repo: "https://github.com/puppetlabs/puppet-postgresql.git"
       ref: "4.9.0"

--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
       "name": "puppetlabs/stdlib"
     },
     {
-      "version_requirement": ">=2.0.0 <4.0.0",
+      "version_requirement": ">=2.0.0 <6.0.0",
       "name": "puppetlabs/mysql"
     },
     {


### PR DESCRIPTION
Currently, due to the upper bound of the `puppetlabs-mysql` dependency, only the version 3.11.0 is pulled in. This PR changes the upper bound to make it possible to use recent versions of the `puppetlabs-mysql` module.